### PR TITLE
3-add-skip-configuration-option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.3.9</maven.version>
@@ -342,6 +343,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <!-- Path to your checkstyle configuration file -->
                     <propertyExpansion>config_loc=${basedir}</propertyExpansion>

--- a/src/main/java/io/github/mjourard/LoadEnvMojo.java
+++ b/src/main/java/io/github/mjourard/LoadEnvMojo.java
@@ -16,6 +16,7 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -45,6 +46,13 @@ public class LoadEnvMojo extends AbstractMojo {
     @Parameter(defaultValue = ".env", property = "envFileName", required = true)
     private String envFileName;
 
+
+    /**
+     * If set to 'true', this plugin will not do anything.
+     */
+    @Parameter(property = "skip", required = false, defaultValue = "false")
+    private Boolean skip;
+
     /**
      * The maven project.
      *
@@ -57,6 +65,10 @@ public class LoadEnvMojo extends AbstractMojo {
     private File targetDir;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("'skip' property found and set to true. Skipping the 'env-file-maven-plugin' plugin.");
+            return;
+        }
         if (envFileDirectory == null || envFileDirectory.isEmpty()) {
             throw new MojoFailureException("env file directory was empty");
         }
@@ -66,7 +78,7 @@ public class LoadEnvMojo extends AbstractMojo {
         }
 
         String tempEnvFileDirectory =  evaluatePath(envFileDirectory);
-        getLog().info("Loading env file from '" + makePathDirectory(tempEnvFileDirectory) + envFileName + "'");
+        getLog().info("Loading env file from '" + makePathDirectory(tempEnvFileDirectory) + FileSystems.getDefault().getSeparator() + envFileName + "'");
 
         Dotenv dotenv = null;
 

--- a/src/site/markdown/changelog.md
+++ b/src/site/markdown/changelog.md
@@ -5,6 +5,7 @@ Changelog
 * updated the directory to properly reflect the package name since that was causing issues running tests while also having used the plugin
 * added checkstyle formatting of the code itself, as well as some vscode settings for easier work done on it in the future.
 * added the bones of a github workflow for eventual publishing of the source code the various distributions and updating the source documentation
+* added a <skip> configuration option. When this is set to 'true' in the <configuration> section of the plugin, then it will not run.
 
 ## 1.1
 * Lowered the required java version from 11 to 8 since no Java 11 features were used in code and 8 is still widely used.

--- a/src/test/java/io/github/mjourard/LoadEnvMojoTest.java
+++ b/src/test/java/io/github/mjourard/LoadEnvMojoTest.java
@@ -8,7 +8,9 @@ import org.junit.Rule;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class LoadEnvMojoTest
@@ -48,6 +50,33 @@ public class LoadEnvMojoTest
         expectedVars.put("PASSWORD", "falconfliesfreely");
 
         checkExpectedEnvVars(expectedVars);
+    }
+
+    @Test
+    public void testSkipConfiguration() throws Exception {
+        File pom = new File( "target/test-classes/project-skips-plugin/" );
+        assertNotNull( pom );
+        assertTrue( pom.exists() );
+
+        List<String> skippedVars = new ArrayList<String>();
+        skippedVars.add("WEBSITE_URL");
+        skippedVars.add("TEMP_USERNAME");
+        skippedVars.add("PASSWORD");
+
+        for (String key : skippedVars) {
+            System.clearProperty(key);
+            String systemVal = System.getProperty(key);
+            assertNull(systemVal);
+        }
+
+        LoadEnvMojo loadEnvMojo = (LoadEnvMojo) rule.lookupConfiguredMojo( pom, "loadenv" );
+        assertNotNull(loadEnvMojo);
+        loadEnvMojo.execute();
+
+        for (String key : skippedVars) {
+            String systemVal = System.getProperty(key);
+            assertNull(systemVal);
+        }
     }
 
     /**

--- a/src/test/resources/project-skips-plugin/directory-of-env-files/should.not.load.env
+++ b/src/test/resources/project-skips-plugin/directory-of-env-files/should.not.load.env
@@ -1,0 +1,4 @@
+#this file is normally gitignored, but we're keeping it for tests
+WEBSITE_URL=https://mjourard.github.io
+TEMP_USERNAME=francis
+PASSWORD=falconfliesfreely

--- a/src/test/resources/project-skips-plugin/pom.xml
+++ b/src/test/resources/project-skips-plugin/pom.xml
@@ -10,7 +10,6 @@
   <packaging>jar</packaging>
   <name>Test MyMojo</name>
   <properties>
-    <!-- dot represents the directory of the pom.xml file of the project   -->
     
   </properties>
 
@@ -22,8 +21,10 @@
         <artifactId>env-file-maven-plugin</artifactId>
         <version>2.0</version>
         <configuration>
+          <skip>true</skip>
+          <!-- dot represents the directory of the pom.xml file of the project   -->
           <envFileDirectory>./directory-of-env-files</envFileDirectory>
-          <envFileName>my.fancy.env</envFileName>
+          <envFileName>should.not.load.env</envFileName>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/project-using-defaults/pom.xml
+++ b/src/test/resources/project-using-defaults/pom.xml
@@ -9,20 +9,17 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Test MyMojo</name>
-  <properties>
-    <!-- testing without the properties defined to test the default properties   -->
-<!--    <envFileDirectory>./</envFileDirectory>-->
-<!--    <envFileName>.env</envFileName>-->
-  </properties>
-
 
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-my-plugin</artifactId>
+        <groupId>io.github.mjourard</groupId>
+        <artifactId>env-file-maven-plugin</artifactId>
+        <version>2.0</version>
         <configuration>
-          <!-- Specify the MyMojo parameter -->
-          <outputDirectory>target/test-harness/project-to-test</outputDirectory>
+          <!-- testing without the properties defined to test the default properties   -->
+          <!--    <envFileDirectory>./</envFileDirectory>-->
+          <!--    <envFileName>.env</envFileName>-->
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Issue: #3 3

## Changes I Have Made
- added support for a <skip> configuration to line up with normal maven plugin capabilities
- updated the test pom files to actually call the plugin properly, and as such use the correct configuration

## How to Test
- run `mvn test`

## Checklist
- [x] All documentation referring to the code that I have changed has been appropriately updated
